### PR TITLE
Fix typo in image-build workflow

### DIFF
--- a/.github/workflows/image-build.yaml
+++ b/.github/workflows/image-build.yaml
@@ -37,4 +37,4 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ steps.metadata.output.tags }}
+          tags: ${{ steps.metadata.outputs.tags }}


### PR DESCRIPTION
This PR fixes a typo in the image-build workflow, where steps.metadata.output was being used instead of
steps.metadata.outputs.

Signed-off-by: John Schaeffer <jschaeffer@equinix.com>