### PR TITLE
Use gcr.io/distroless/base instead of gcr.io/distroless/static

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ COPY . ./
 # -mod=readonly ensures immutable go.mod and go.sum in container builds.
 RUN CGO_ENABLED=0 GOOS=linux go build -mod=readonly -v -o identity-manager-sts
 
-FROM gcr.io/distroless/static:nonroot AS runner
+FROM gcr.io/distroless/base:nonroot AS runner
 
 # `nonroot` coming from distroless
 USER 65532:65532


### PR DESCRIPTION
In-memory CRDB fails to run when using gcr.io/distroless/static but works using gcr.io/distroless/base. This PR updates the runner stage to use gcr.io/distroless/base instead so we can get running with Helm and such without needing to set up a whole CRDB deployment.

Signed-off-by: John Schaeffer <jschaeffer@equinix.com>