### PR TITLE
Set issued_token_type and token_type in exchange response correctly

### DIFF
--- a/internal/rfc8693/rfc8693.go
+++ b/internal/rfc8693/rfc8693.go
@@ -29,6 +29,8 @@ const (
 	ParamActorTokenType = "actor_token_type"
 	// ClaimClientID is the claim for the client ID.
 	ClaimClientID = "client_id"
+
+	responseIssuedTokenType = "issued_token_type"
 )
 
 var (
@@ -242,7 +244,8 @@ func (s *TokenExchangeHandler) PopulateTokenEndpointResponse(ctx context.Context
 	}
 
 	responder.SetAccessToken(token)
-	responder.SetTokenType(TokenTypeJWT)
+	responder.SetExtra(responseIssuedTokenType, TokenTypeJWT)
+	responder.SetTokenType(fosite.BearerAccessToken)
 	responder.SetExpiresIn(s.config.GetAccessTokenLifespan(ctx))
 
 	return nil


### PR DESCRIPTION
issued_token_type was not being set in the token exchange response and token_type was set to an incorrect value. This PR fixes both issues.

Signed-off-by: John Schaeffer <jschaeffer@equinix.com>