### PR TITLE
Helm chart key updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,52 @@
+name: release
+on:
+  push:
+    tags: '*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Publish Helm charts
+        uses: stefanprodan/helm-gh-pages@master
+        with:
+          token: ${{ secrets.RELEASEBOT_PAT }}
+          charts_dir: chart
+          charts_url: "https://infratographer.github.io/charts"
+          repository: "charts"
+          app_version: ${{  github.ref_name }}
+          chart_version: ${{  github.ref_name }}
+          branch: gh-pages
+
+  image-build:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Registry Login
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker Metadata
+        id: metadata
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=tag
+      - name: Build+Push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.metadata.outputs.tags }}

--- a/chart/identity-manager-sts/Chart.yaml
+++ b/chart/identity-manager-sts/Chart.yaml
@@ -1,10 +1,10 @@
 ---
 apiVersion: v1
-appVersion: 0.0.1
+appVersion: v0.0.1
 description: A Helm chart for Identity-manager STS a RFC 8693 token exchange server.
 name: identity-manager-sts
 keywords:
-version: 0.0.1
+version: v0.0.1
 home: http://github.com/infratographer/identity-manager-sts
 dependencies:
   - name: common

--- a/chart/identity-manager-sts/templates/_helpers.tpl
+++ b/chart/identity-manager-sts/templates/_helpers.tpl
@@ -15,5 +15,5 @@ Create the SeedIssuer object to bootstrap the token exchange with an issuer.
 {{- end }}
 
 {{- define "im-sts.listenPort" }}
-{{- .Values.identityManagerSTS.config.server.port | default 8080 }}
+{{- .Values.config.server.port | default 8080 }}
 {{- end }}

--- a/chart/identity-manager-sts/templates/configMap.yaml
+++ b/chart/identity-manager-sts/templates/configMap.yaml
@@ -1,6 +1,6 @@
 ---
 {{- $serverPort := include "im-sts.listenPort" . }}
-{{- $serverIP := .Values.identityManagerSTS.config.server.ip }}
+{{- $serverIP := .Values.config.server.ip }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -9,7 +9,7 @@ metadata:
   labels:
     {{- include "common.labels.standard" . | nindent 4 }}
 data:
-  {{- with .Values.identityManagerSTS.config }}
+  {{- with .Values.config }}
   identity-manager-sts.yaml: |
     server:
       listen: "{{ $serverIP }}:{{ $serverPort }}"

--- a/chart/identity-manager-sts/templates/deployment.yaml
+++ b/chart/identity-manager-sts/templates/deployment.yaml
@@ -1,21 +1,20 @@
 ---
-{{- $oauthCfg := .Values.identityManagerSTS.config.oauth }}
 apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   labels:
     {{- include "common.labels.standard" . | nindent 4 }}
-    {{- with .Values.identityManagerSTS.extraLabels }}
+    {{- with .Values.deployment.extraLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- with .Values.identityManagerSTS.extraAnnotations }}
+  {{- with .Values.deployment.extraAnnotations }}
   annotations:
     {{ toYaml . | nindent 4 }}
   {{- end }}
   name: {{ template "common.names.fullname" . }}
   namespace: {{ .Release.Namespace }}
 spec:
-  replicas: {{ .Values.identityManagerSTS.replicas }}
+  replicas: {{ .Values.deployment.replicas }}
   revisionHistoryLimit: 3
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
@@ -23,10 +22,10 @@ spec:
     metadata:
       labels:
         {{- include "common.labels.standard" . | nindent 8 }}
-        {{- with .Values.identityManagerSTS.extraLabels }}
+        {{- with .Values.deployment.extraLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.identityManagerSTS.annotations }}
+      {{- with .Values.deployment.annotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -40,8 +39,8 @@ spec:
           command:
             - /bin/sh
             - -c
-            - "cp -f /sts-keys/* /keys/; chown {{ .Values.identityManagerSTS.containerUserID }} /keys/*"
-          {{- with .Values.identityManagerSTS.resources }}
+            - "cp -f /sts-keys/* /keys/; chown {{ .Values.deployment.containerUserID }} /keys/*"
+          {{- with .Values.deployment.resources }}
           resources:
           {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -54,7 +53,7 @@ spec:
         - name: {{ include "common.names.name" . }}
           envFrom:
             - secretRef:
-                name: "{{ $oauthCfg.secretName }}"
+                name: "{{ .Values.config.oauth.secretName }}"
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy | default "Always" }}
           volumeMounts:
@@ -66,14 +65,14 @@ spec:
           ports:
             - name: web
               containerPort: {{ include "im-sts.listenPort" . }}
-          {{- with .Values.identityManagerSTS.resources }}
+          {{- with .Values.deployment.resources }}
           resources:
           {{- toYaml . | nindent 12 }}
           {{- end }}
       volumes:
         - name: signing-keys-seed
           secret:
-            secretName: "{{ $oauthCfg.privateKeys.secretName }}"
+            secretName: "{{ .Values.config.oauth.privateKeys.secretName }}"
             defaultMode: 0400
         - name: signing-keys
           emptyDir:

--- a/chart/identity-manager-sts/values.yaml
+++ b/chart/identity-manager-sts/values.yaml
@@ -9,80 +9,77 @@ copyKeys:
   pullPolicy: IfNotPresent
   tag: "latest"
 
-# identityManagerSTS has all the knobs for the deployment
-identityManagerSTS:
-
+deployment:
   replicas: 3
-
   extraLabels: {}
   annotations: {}
   resources: {}
 
   containerUserID: 65532
 
-  # config builds the application configuration, non-sensitive pieces
-  # end up in the configMap. sensitive things such as oauth secret and
-  # private keys are mounted as environment variables or read-only
-  # volumeMounts.
-  config:
-    server:
-      ip: "0.0.0.0"
-      port: 8080
+# config builds the application configuration, non-sensitive pieces
+# end up in the configMap. sensitive things such as oauth secret and
+# private keys are mounted as environment variables or read-only
+# volumeMounts.
+config:
+  server:
+    ip: "0.0.0.0"
+    port: 8080
 
-    otel:
-      enabled: false
-      provider: stdout
-      stdout:
-        prettyPrint: true
+  otel:
+    enabled: false
+    provider: stdout
+    stdout:
+      prettyPrint: true
 
-    storage:
-      type: memory
+  storage:
+    type: memory
 
-      # Configure the issuers to trust upon initial deployment
-      seedData:
+    # Configure the issuers to trust upon initial deployment
+    seedData:
 
-        # Issuers is how you configure the issuers to trust when
-        # bootstrapping the application issuers is a map with the
-        # following format:
-        # ```yaml
-        #   - name: "Example"
-        #     uri: "https://auth.example.com/"
-        #     jwksURI: "https://auth.example.com/.well-known/jwks.json"
-        #     claimMappings:
-        #       "infratographer:sub": "'infratographer://example.com/' + subSHA256"
-        #```
-        issuers: []
+      # Issuers is how you configure the issuers to trust when
+      # bootstrapping the application issuers is a map with the
+      # following format:
+      # ```yaml
+      #   - name: "Example"
+      #     uri: "https://auth.example.com/"
+      #     jwksURI: "https://auth.example.com/.well-known/jwks.json"
+      #     claimMappings:
+      #       "infratographer:sub": "'infratographer://example.com/' + subSHA256"
+      #```
+      issuers: []
 
-    oauth:
-      # issuer is the `iss` claim in the exchanged tokens
-      issuer: ""
+  oauth:
+    # issuer is the `iss` claim in the exchanged tokens
+    issuer: "a"
 
-      # accessTokenLifespan is the lifetime of exchanged tokens
-      accessTokenLifespan: 600
+    # accessTokenLifespan is the lifetime of exchanged tokens
+    accessTokenLifespan: 600
 
-      secretName: ""
+    secretName: "b"
 
-      # Private keys used to mint JWTs
-      privateKeys:
-        # secretName specifies the secret where all signing keys live
-        # the secret should contain PEM private keys. These are mounted
-        # in the container at `/keys/`
-        secretName: ""
+    # Private keys used to mint JWTs
+    privateKeys:
+      # secretName specifies the secret where all signing keys live
+      # the secret should contain PEM private keys. These are mounted
+      # in the container at `/keys/`
+      secretName: "c"
 
-        # keys is an array of objects which specify the keys to be
-        # used when creating and signing JWTs
-        #
-        # Each keyID should match a key in the secret above.
-        #
-        # ```yaml
-        #  - keyID: default
-        #    path: /keys/default.pem
-        #    algorithm: RS256
-        # ```
-        keys:
-          - keyID: default
-            path: "/keys/default.pem"
-            algorithm: RS256
+      # keys is an array of objects which specify the keys to be
+      # used when creating and signing JWTs
+      #
+      # Each keyID should match a key in the secret above.
+      #
+      # ```yaml
+      #  - keyID: default
+      #    path: /keys/default.pem
+      #    algorithm: RS256
+      # ```
+      keys:
+        - keyID: default
+          path: "/keys/default.pem"
+          algorithm: RS256
 
 ingress:
   enabled: false

--- a/chart/identity-manager-sts/values.yaml
+++ b/chart/identity-manager-sts/values.yaml
@@ -52,19 +52,19 @@ config:
 
   oauth:
     # issuer is the `iss` claim in the exchanged tokens
-    issuer: "a"
+    issuer: ""
 
     # accessTokenLifespan is the lifetime of exchanged tokens
     accessTokenLifespan: 600
 
-    secretName: "b"
+    secretName: ""
 
     # Private keys used to mint JWTs
     privateKeys:
       # secretName specifies the secret where all signing keys live
       # the secret should contain PEM private keys. These are mounted
       # in the container at `/keys/`
-      secretName: "c"
+      secretName: ""
 
       # keys is an array of objects which specify the keys to be
       # used when creating and signing JWTs


### PR DESCRIPTION
This removes the chart top-level key `identityManagerSTS` since it'll be cleaner for downstream charts to depend on this. This also adds the workflow to update the charts repo when we tag a release.